### PR TITLE
CKAN 2.10 Upgrade fix

### DIFF
--- a/ckanext/check_link/logic/action/report.py
+++ b/ckanext/check_link/logic/action/report.py
@@ -14,7 +14,7 @@ import logging
 
 from ckan.lib import mailer
 import socket
-from jinja2 import escape
+from markupsafe import escape
 from flask import render_template
 
 action, get_actions = Collector("check_link").split()


### PR DESCRIPTION
Changed 'from jinja2 import escape' to 'from markupsafe import escape'